### PR TITLE
Fixed fatal error when exception message is an object

### DIFF
--- a/src/Bigcommerce/Api/Error.php
+++ b/src/Bigcommerce/Api/Error.php
@@ -12,6 +12,9 @@ class Error extends \Exception
         if (is_array($message)) {
             $message = $message[0]->message;
         }
+         else if (is_object($message) && isset($message->error)) {
+            $message = $message->error;
+        }
 
         parent::__construct($message, $code);
     }


### PR DESCRIPTION
Fatal error: Wrong parameters for Exception([string $exception [, long $code [, Exception $previous = NULL]]]) in ../vendor/bigcommerce/api/src/Bigcommerce/Api/Error.php on line 18

BigCommerce 401 response {"error":"You are authorized but your scope does not include this resource."}
