### PR TITLE
Support for fetching newsletter subscribers INT-377

### DIFF
--- a/src/Bigcommerce/Api/Client.php
+++ b/src/Bigcommerce/Api/Client.php
@@ -258,7 +258,19 @@ class Client
      */
     public static function getCollection($path, $resource = 'Resource')
     {
-        $response = self::connection()->get(self::$api_path . $path);
+        $apiVersion = 2;
+        $api_path = self::$api_path;
+
+        if (strpos($path, '/customers/subscribers') !== false) {
+            $apiVersion = 3;
+            $api_path = str_replace('v2', 'v3', $api_path);   
+        }
+
+        $response = self::connection()->get($api_path . $path);
+
+        if ($apiVersion == 3) {
+            $response = $response->data;
+        }
 
         return self::mapCollection($resource, $response);
     }
@@ -981,6 +993,18 @@ class Client
     public static function updateOrder($id, $object)
     {
         return self::updateResource('/orders/' . $id, $object);
+    }
+
+    /**
+     * The list of newsletter subscribers.
+     *
+     * @param array $filter
+     * @return array
+     */
+    public static function getSubscribers($filter = array())
+    {
+        $filter = Filter::create($filter);
+        return self::getCollection('/customers/subscribers' . $filter->toQuery(), 'Subscriber');
     }
 
     /**

--- a/src/Bigcommerce/Api/Client.php
+++ b/src/Bigcommerce/Api/Client.php
@@ -261,14 +261,15 @@ class Client
         $apiVersion = 2;
         $api_path = self::$api_path;
 
-        if (strpos($path, '/customers/subscribers') !== false) {
+        if ($resource === 'Subscriber') {
             $apiVersion = 3;
             $api_path = str_replace('v2', 'v3', $api_path);   
         }
 
         $response = self::connection()->get($api_path . $path);
 
-        if ($apiVersion == 3) {
+        if ($apiVersion === 3) {
+            // Version 3 endpoint response data is found here
             $response = $response->data;
         }
 

--- a/src/Bigcommerce/Api/Resources/Subscriber.php
+++ b/src/Bigcommerce/Api/Resources/Subscriber.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Bigcommerce\Api\Resources;
+
+use Bigcommerce\Api\Resource;
+use Bigcommerce\Api\Client;
+
+class Subscriber extends Resource
+{
+    protected $ignoreOnCreate = array(
+        'id',
+    );
+
+    protected $ignoreOnUpdate = array(
+        'id',
+    );
+
+    public function getLoginToken()
+    {
+        return Client::getCustomerLoginToken($this->id);
+    }
+}


### PR DESCRIPTION
### Abstract

For our "accepts marketing" backfill sync script, we need to fetch BigCommerce customers that opted-in to marketing. The problem is this data is not available with the `/customers` endpoint (it is only available at `/customers/subscribers`). This PR updates the BigCommerce SDK to support fetching subscribers.

### Technical Description

The [subscribers endpoint](https://developer.bigcommerce.com/api/v3/customers.html#getsubscribers) is only available with version 3 of the BigCommerce API. Their current SDK does not provide support for using version 3 endpoints, so I had to hack this in there.

### Acceptance Criteria

- [ ] Be able to fetch newsletter subscribers (from checkout) using the BigCommerce SDK

**Team:** @ActiveCampaign/integration 
