### PR TITLE
Ability to fetch a single newsletter subscriber INT-397

### DIFF
--- a/src/Bigcommerce/Api/Client.php
+++ b/src/Bigcommerce/Api/Client.php
@@ -285,7 +285,20 @@ class Client
      */
     public static function getResource($path, $resource = 'Resource')
     {
-        $response = self::connection()->get(self::$api_path . $path);
+        $apiVersion = 2;
+        $api_path = self::$api_path;
+
+        if ($resource === 'Subscriber') {
+            $apiVersion = 3;
+            $api_path = str_replace('v2', 'v3', $api_path);   
+        }
+
+        $response = self::connection()->get($api_path . $path);
+
+        if ($apiVersion === 3) {
+            // Version 3 endpoint response data is found here
+            $response = $response->data;
+        }
 
         return self::mapResource($resource, $response);
     }
@@ -1006,6 +1019,17 @@ class Client
     {
         $filter = Filter::create($filter);
         return self::getCollection('/customers/subscribers' . $filter->toQuery(), 'Subscriber');
+    }
+
+    /**
+     * A single subscriber.
+     *
+     * @param array $filter
+     * @return Resources\Subscriber
+     */
+    public static function getSubscriber($filter = array())
+    {
+        return self::getResource('/customers/subscribers' . $filter->toQuery(), 'Subscriber');
     }
 
     /**

--- a/src/Bigcommerce/Api/Client.php
+++ b/src/Bigcommerce/Api/Client.php
@@ -1029,6 +1029,7 @@ class Client
      */
     public static function getSubscriber($filter = array())
     {
+        $filter = Filter::create($filter);
         return self::getResource('/customers/subscribers' . $filter->toQuery(), 'Subscriber');
     }
 


### PR DESCRIPTION
### Abstract

When running a BigCommerce historical sync or processing webhooks, we need to fetch a customer's subscriber status: whether or not they opted in to accepts marketing on the cart/checkout page.

This is a separate API endpoint and thus requires some logic similar to #2.

### Technical Description

Same exact logic as #2 . Here we filter on email address so the final endpoint looks like: `/v3/customers/subscribers?email=test%40test.com`

This will be used for https://github.com/ActiveCampaign/data-collection/pull/422

### Acceptance Criteria

- [ ] Be able to fetch a single newsletter subscriber using the BigCommerce SDK

**Team:** @ActiveCampaign/integration 
