### PR TITLE
Fatal throwable error fix

### DIFF
--- a/src/Bigcommerce/Api/Client.php
+++ b/src/Bigcommerce/Api/Client.php
@@ -285,7 +285,20 @@ class Client
      */
     public static function getResource($path, $resource = 'Resource')
     {
-        $response = self::connection()->get(self::$api_path . $path);
+        $apiVersion = 2;
+        $api_path = self::$api_path;
+
+        if ($resource === 'Subscriber') {
+            $apiVersion = 3;
+            $api_path = str_replace('v2', 'v3', $api_path);   
+        }
+
+        $response = self::connection()->get($api_path . $path);
+
+        if ($apiVersion === 3) {
+            // Version 3 endpoint response data is found here
+            $response = $response->data;
+        }
 
         return self::mapResource($resource, $response);
     }
@@ -1006,6 +1019,17 @@ class Client
     {
         $filter = Filter::create($filter);
         return self::getCollection('/customers/subscribers' . $filter->toQuery(), 'Subscriber');
+    }
+
+    /**
+     * A single subscriber.
+     *
+     * @param array $filter
+     * @return Resources\Subscriber
+     */
+    public static function getSubscriber($filter = array())
+    {
+        return self::getResource('/customers/subscribers' . $filter->toQuery(), 'Subscriber');
     }
 
     /**

--- a/src/Bigcommerce/Api/Client.php
+++ b/src/Bigcommerce/Api/Client.php
@@ -258,7 +258,19 @@ class Client
      */
     public static function getCollection($path, $resource = 'Resource')
     {
-        $response = self::connection()->get(self::$api_path . $path);
+        $apiVersion = 2;
+        $api_path = self::$api_path;
+
+        if (strpos($path, '/customers/subscribers') !== false) {
+            $apiVersion = 3;
+            $api_path = str_replace('v2', 'v3', $api_path);   
+        }
+
+        $response = self::connection()->get($api_path . $path);
+
+        if ($apiVersion == 3) {
+            $response = $response->data;
+        }
 
         return self::mapCollection($resource, $response);
     }
@@ -981,6 +993,18 @@ class Client
     public static function updateOrder($id, $object)
     {
         return self::updateResource('/orders/' . $id, $object);
+    }
+
+    /**
+     * The list of newsletter subscribers.
+     *
+     * @param array $filter
+     * @return array
+     */
+    public static function getSubscribers($filter = array())
+    {
+        $filter = Filter::create($filter);
+        return self::getCollection('/customers/subscribers' . $filter->toQuery(), 'Subscriber');
     }
 
     /**

--- a/src/Bigcommerce/Api/Client.php
+++ b/src/Bigcommerce/Api/Client.php
@@ -1029,6 +1029,7 @@ class Client
      */
     public static function getSubscriber($filter = array())
     {
+        $filter = Filter::create($filter);
         return self::getResource('/customers/subscribers' . $filter->toQuery(), 'Subscriber');
     }
 

--- a/src/Bigcommerce/Api/Client.php
+++ b/src/Bigcommerce/Api/Client.php
@@ -261,14 +261,15 @@ class Client
         $apiVersion = 2;
         $api_path = self::$api_path;
 
-        if (strpos($path, '/customers/subscribers') !== false) {
+        if ($resource === 'Subscriber') {
             $apiVersion = 3;
             $api_path = str_replace('v2', 'v3', $api_path);   
         }
 
         $response = self::connection()->get($api_path . $path);
 
-        if ($apiVersion == 3) {
+        if ($apiVersion === 3) {
+            // Version 3 endpoint response data is found here
             $response = $response->data;
         }
 

--- a/src/Bigcommerce/Api/Error.php
+++ b/src/Bigcommerce/Api/Error.php
@@ -12,6 +12,9 @@ class Error extends \Exception
         if (is_array($message)) {
             $message = $message[0]->message;
         }
+         else if (is_object($message) && isset($message->error)) {
+            $message = $message->error;
+        }
 
         parent::__construct($message, $code);
     }

--- a/src/Bigcommerce/Api/Error.php
+++ b/src/Bigcommerce/Api/Error.php
@@ -12,8 +12,8 @@ class Error extends \Exception
         if (is_array($message)) {
             $message = $message[0]->message;
         }
-         else if (is_object($message) && isset($message->error)) {
-            $message = $message->error;
+        else if (is_object($message)) {
+            $message = isset($message->error) ? $message->error : var_export($message, true);
         }
 
         parent::__construct($message, $code);

--- a/src/Bigcommerce/Api/Resources/Subscriber.php
+++ b/src/Bigcommerce/Api/Resources/Subscriber.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Bigcommerce\Api\Resources;
+
+use Bigcommerce\Api\Resource;
+use Bigcommerce\Api\Client;
+
+class Subscriber extends Resource
+{
+    protected $ignoreOnCreate = array(
+        'id',
+    );
+
+    protected $ignoreOnUpdate = array(
+        'id',
+    );
+
+    public function getLoginToken()
+    {
+        return Client::getCustomerLoginToken($this->id);
+    }
+}


### PR DESCRIPTION
[Jira](https://at.activecampaign.com/browse/INT-1055)
[Sentry](https://sentry.io/organizations/activecampaign/issues/795771901/events/614adc00c1ba44a9904ac7ee578b6ebe/)

The Bigcommerce API Client is receiving some 4xx response. It tries to throw a ClientError Exception but the message passed is some object without an error property. This causes a fatal throwable exception since the constructor of its parent's parent is expecting a string as the message parameter.

The fix chosen here is to convert the object to a string and pass it to the constructor as the message. This is to preserve whatever information might be present in the object as opposed to using some generic text as the message.