### PR TITLE
Fatal Error fix

### DIFF
--- a/src/Bigcommerce/Api/Error.php
+++ b/src/Bigcommerce/Api/Error.php
@@ -12,8 +12,8 @@ class Error extends \Exception
         if (is_array($message)) {
             $message = $message[0]->message;
         }
-         else if (is_object($message) && isset($message->error)) {
-            $message = $message->error;
+        else if (is_object($message)) {
+            $message = isset($message->error) ? $message->error : var_export($message, true);
         }
 
         parent::__construct($message, $code);


### PR DESCRIPTION
[Jira](https://at.activecampaign.com/browse/INT-1055)
[Sentry](https://sentry.io/organizations/activecampaign/issues/795771901/?project=1308419&referrer=jira_integration)

This is a forked package of an API client used in Deepdata to send things to BigCommerce we are stuck with this fork since changes have to been made to support aspects of the Bigcommerce v3 API. There is not an API v3 client package available in php.

The Bigcommerce API Client is receiving some 4xx response. It tries to throw a ClientError Exception but the message passed is some object without an error property. This causes a fatal throwable exception since the constructor of its parent's parent is expecting a string as the message parameter.

The fix chosen here is to convert the object to a string and pass it to the constructor as the message. This is to preserve whatever information might be present in the object as opposed to using some generic text as the message.

This does not resolve the underlying issue but this will allow us to actually see the error(s).